### PR TITLE
translated

### DIFF
--- a/util/responses/German/success/general.json
+++ b/util/responses/German/success/general.json
@@ -15,7 +15,7 @@
         "updated": {
             "a":"wurde auf",
             "b": "geupdated",
-            "c": "can now be refered to as",
+            "c": "hat jetzt den alias",
             "d": ""
         },
 


### PR DESCRIPTION
Not the cleanest german translation but there is not a 'good' way to translated `refered to as` to german so i used `alias` wich is the same in german